### PR TITLE
Add basic provider and receiver modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Broadcaster
+
+This project provides a minimal provider/receiver example using Boost.Asio.
+
+## Building
+
+```
+g++ -std=c++17 src/provider.cpp src/signal_analysis.cpp -o provider -lboost_system
+g++ -std=c++17 src/receiver.cpp src/signal_analysis.cpp -o receiver -lboost_system
+```
+
+## Running
+1. Start the provider:
+   ```
+   ./provider
+   ```
+2. Run the receiver in another terminal:
+   ```
+   ./receiver
+   ```
+

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+class Encoder {
+public:
+    virtual ~Encoder() = default;
+    virtual std::vector<uint8_t> encode(const std::vector<uint8_t>& data) = 0;
+};
+
+class IdentityEncoder : public Encoder {
+public:
+    std::vector<uint8_t> encode(const std::vector<uint8_t>& data) override { return data; }
+};

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -1,0 +1,59 @@
+#include <boost/asio.hpp>
+#include <iostream>
+#include <vector>
+#include "signal_analysis.h"
+#include "encoding.h"
+
+using boost::asio::ip::tcp;
+
+class Server {
+public:
+    Server(boost::asio::io_context& io, unsigned short port, Encoder* encoder, SignalAnalyzer* analyzer)
+        : acceptor_(io, tcp::endpoint(tcp::v4(), port)), encoder_(encoder), analyzer_(analyzer) {
+        accept();
+    }
+
+private:
+    void accept() {
+        socket_.emplace(acceptor_.get_executor());
+        acceptor_.async_accept(*socket_, [this](boost::system::error_code ec) {
+            if (!ec) {
+                std::cout << "Client connected" << std::endl;
+                send_data();
+            }
+        });
+    }
+
+    void send_data() {
+        std::vector<uint8_t> raw{ 'H', 'e', 'l', 'l', 'o' };
+        if (encoder_) raw = encoder_->encode(raw);
+        if (analyzer_) analyzer_->analyze(raw);
+        uint32_t len = static_cast<uint32_t>(raw.size());
+        std::vector<uint8_t> buffer(4 + raw.size());
+        buffer[0] = (len >> 24) & 0xFF;
+        buffer[1] = (len >> 16) & 0xFF;
+        buffer[2] = (len >> 8) & 0xFF;
+        buffer[3] = len & 0xFF;
+        std::copy(raw.begin(), raw.end(), buffer.begin() + 4);
+        boost::asio::async_write(*socket_, boost::asio::buffer(buffer),
+            [this](boost::system::error_code ec, std::size_t) {
+                if (!ec) {
+                    std::cout << "Data sent" << std::endl;
+                }
+            });
+    }
+
+    tcp::acceptor acceptor_;
+    std::optional<tcp::socket> socket_;
+    Encoder* encoder_;
+    SignalAnalyzer* analyzer_;
+};
+
+int main() {
+    boost::asio::io_context io;
+    Encoder* encoder = nullptr; // hook for custom encoding
+    SignalAnalyzer* analyzer = nullptr; // hook for signal analysis
+    Server srv(io, 12345, encoder, analyzer);
+    io.run();
+    return 0;
+}

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -1,0 +1,65 @@
+#include <boost/asio.hpp>
+#include <iostream>
+#include <vector>
+#include "signal_analysis.h"
+#include "encoding.h"
+
+using boost::asio::ip::tcp;
+
+class Client {
+public:
+    Client(boost::asio::io_context& io, const std::string& host, unsigned short port,
+           Encoder* encoder, SignalAnalyzer* analyzer)
+        : socket_(io), encoder_(encoder), analyzer_(analyzer) {
+        tcp::resolver resolver(io);
+        auto endpoints = resolver.resolve(host, std::to_string(port));
+        boost::asio::async_connect(socket_, endpoints,
+            [this](boost::system::error_code ec, tcp::endpoint) {
+                if (!ec) {
+                    receive();
+                }
+            });
+    }
+
+private:
+    void receive() {
+        boost::asio::async_read(socket_, boost::asio::buffer(len_buf_),
+            [this](boost::system::error_code ec, std::size_t) {
+                if (!ec) {
+                    uint32_t len = (static_cast<uint32_t>(len_buf_[0]) << 24) |
+                                    (static_cast<uint32_t>(len_buf_[1]) << 16) |
+                                    (static_cast<uint32_t>(len_buf_[2]) << 8) |
+                                    static_cast<uint32_t>(len_buf_[3]);
+                    data_buf_.resize(len);
+                    read_body(len);
+                }
+            });
+    }
+
+    void read_body(std::size_t len) {
+        boost::asio::async_read(socket_, boost::asio::buffer(data_buf_),
+            [this](boost::system::error_code ec, std::size_t) {
+                if (!ec) {
+                    if (analyzer_) analyzer_->analyze(data_buf_);
+                    if (encoder_) data_buf_ = encoder_->encode(data_buf_); // decode if symmetric
+                    std::string text(data_buf_.begin(), data_buf_.end());
+                    std::cout << "Received: " << text << std::endl;
+                }
+            });
+    }
+
+    tcp::socket socket_;
+    std::array<uint8_t,4> len_buf_{};
+    std::vector<uint8_t> data_buf_;
+    Encoder* encoder_;
+    SignalAnalyzer* analyzer_;
+};
+
+int main() {
+    boost::asio::io_context io;
+    Encoder* encoder = nullptr;
+    SignalAnalyzer* analyzer = nullptr;
+    Client cl(io, "127.0.0.1", 12345, encoder, analyzer);
+    io.run();
+    return 0;
+}

--- a/src/signal_analysis.cpp
+++ b/src/signal_analysis.cpp
@@ -1,0 +1,6 @@
+#include "signal_analysis.h"
+#include <iostream>
+
+void SimpleLogger::analyze(const std::vector<uint8_t>& data) {
+    std::cout << "Analyzing data of size " << data.size() << std::endl;
+}

--- a/src/signal_analysis.h
+++ b/src/signal_analysis.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+class SignalAnalyzer {
+public:
+    virtual ~SignalAnalyzer() = default;
+    virtual void analyze(const std::vector<uint8_t>& data) = 0;
+};
+
+class SimpleLogger : public SignalAnalyzer {
+public:
+    void analyze(const std::vector<uint8_t>& data) override;
+};


### PR DESCRIPTION
## Summary
- implement provider and receiver using Boost.Asio
- add signal analysis and encoding interfaces
- document compile and run instructions in README

## Testing
- `pytest -q`
- `g++ -std=c++17 -c src/provider.cpp` *(fails: boost/asio.hpp not found)*
- `g++ -std=c++17 -c src/receiver.cpp` *(fails: boost/asio.hpp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f5117a5883239c8935be8fc679fd