### PR TITLE
Add simple HDMI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This project provides a minimal provider/receiver example using Boost.Asio.
 ## Building
 
 ```
-g++ -std=c++17 src/provider.cpp src/signal_analysis.cpp -o provider -lboost_system
-g++ -std=c++17 src/receiver.cpp src/signal_analysis.cpp -o receiver -lboost_system
+g++ -std=c++17 src/provider.cpp src/signal_analysis.cpp src/hdmi.cpp -o provider -lboost_system
+g++ -std=c++17 src/receiver.cpp src/signal_analysis.cpp src/hdmi.cpp -o receiver -lboost_system
 ```
 
 ## Running

--- a/src/hdmi.cpp
+++ b/src/hdmi.cpp
@@ -1,0 +1,21 @@
+#include "hdmi.h"
+
+bool HDMIOutput::connect() {
+    std::cout << "HDMI output connected." << std::endl;
+    return true;
+}
+
+void HDMIOutput::sendFrame(const std::vector<uint8_t>& frame) {
+    std::cout << "Sending HDMI frame of size " << frame.size() << std::endl;
+}
+
+bool HDMIInput::connect() {
+    std::cout << "HDMI input connected." << std::endl;
+    return true;
+}
+
+std::vector<uint8_t> HDMIInput::receiveFrame() {
+    std::vector<uint8_t> dummy(1920 * 1080 * 3, 0);
+    std::cout << "Receiving HDMI frame of size " << dummy.size() << std::endl;
+    return dummy;
+}

--- a/src/hdmi.h
+++ b/src/hdmi.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+#include <iostream>
+
+class HDMIOutput {
+public:
+    bool connect();
+    void sendFrame(const std::vector<uint8_t>& frame);
+};
+
+class HDMIInput {
+public:
+    bool connect();
+    std::vector<uint8_t> receiveFrame();
+};


### PR DESCRIPTION
## Summary
- add HDMIOutput/HDMIInput interface and stubs
- use HDMI output in provider and receiver
- update build commands

## Testing
- `g++ -std=c++17 src/provider.cpp src/signal_analysis.cpp src/hdmi.cpp -o provider -lboost_system` *(fails: boost/asio.hpp missing)*
- `g++ -std=c++17 src/receiver.cpp src/signal_analysis.cpp src/hdmi.cpp -o receiver -lboost_system` *(fails: boost/asio.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879f9569eac8323ba5c24b8e0b28738